### PR TITLE
Update DownloadFile.ps1

### DIFF
--- a/DownloadFile.ps1
+++ b/DownloadFile.ps1
@@ -14,12 +14,10 @@ else{
 }
 
 $latestRelease.assets[0].browser_download_url
-$lastVersionTimeStamp = ''
 $lastVersionTimeStamp = Get-Content -Path (Join-Path $PSScriptRoot 'lastversion.txt') -ErrorAction SilentlyContinue
 
-if ($lastVersionTimeStamp -eq '') {
+if ([string]::IsNullOrEmpty($lastVersionTimeStamp)) {
     $lastVersionTimeStamp = '0001-01-01T00:00:00Z'
-
 }
 
 if (((Get-Date $lastVersionTimeStamp) -lt (Get-Date $latestRelease.assets[0].updated_at )) -or (-not (Test-Path $TargetPath -PathType leaf))) {


### PR DESCRIPTION
If no lastversion.txt exist, Get-Content returns null and default lastVersionTimeStamp is not set

```
Get-Date : Cannot bind parameter 'Date' to the target. Exception setting "Date": "Cannot convert null to type "System.DateTime"."
At C:\GIT\Scripts\Development\Devops\DownloadBCLinterCop.ps1:25 char:16
```