### PR TITLE
Json Syntax for LinterCop.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 	"version": "0.1.4",
 	"preview": true,
 	"engines": {
-		"vscode": "^1.46.0"
+		"vscode": "^1.70.0"
 	},
 	"categories": [
 		"Linters"
@@ -54,7 +54,13 @@
 					}
 				}
 			}
-		]
+		],
+		"jsonValidation": [
+			{
+			  "fileMatch": "LinterCop.json",
+			  "url": "./syntaxes/LinterSettingsSyntax.json"
+			}
+		  ]
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
@@ -65,7 +71,7 @@
 		"test": "node ./out/test/runTest.js"
 	},
 	"devDependencies": {
-		"@types/vscode": "^1.46.0",
+		"@types/vscode": "^1.70.0",
 		"@types/glob": "^7.1.3",
 		"@types/mocha": "^8.0.4",
 		"@types/node": "^12.11.7",

--- a/syntaxes/LinterSettingsSyntax.json
+++ b/syntaxes/LinterSettingsSyntax.json
@@ -1,0 +1,42 @@
+{
+  "$id": "LinterCop Settings Syntax",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Schema for the LinterCop.json file.",
+  "type": "object",
+  "required": [],
+  "properties": {
+    "cyclomaticComplexetyThreshold": {
+      "description": "This setting is replaced by cyclomaticComplexityThreshold, due to misspelling.",
+      "type": "integer",
+      "default": 8,
+      "minimum": 0,
+      "deprecated": true
+    },
+    "maintainablityIndexThreshold": {
+      "description": "This setting is replaced by maintainabilityIndexThreshold, due to misspelling.",
+      "type": "integer",
+      "default": 20,
+      "minimum": 0,
+      "maximum": 100,
+      "deprecated": true
+    },
+    "cyclomaticComplexityThreshold": {
+      "description": "The threshold value for the Cyclomatic Complexity check. Cyclomatic Complexity is a metric to show how complex a piece of code is. To calculate this value, the number of decisions or code paths is used. Used by LC0010. Default Value: 8",
+      "type": "integer",
+      "default": 8,
+      "minimum": 0
+    },
+    "maintainabilityIndexThreshold": {
+      "description": "The threshold value, between 0 and 100, for the Maintainability Index check. The Maintainability Index value represents the relative ease of maintaining the code. A high value means better maintainability. Default Value: 20",
+      "type": "integer",
+      "default": 20,
+      "minimum": 0,
+      "maximum": 100
+    },
+    "enableRule0011ForTableFields": {
+      "description": "Enables the LC0011 rule for Table Fields. (Every object needs to specify a value for the Access property)",
+      "type": "boolean",
+      "default": false
+    }
+  }
+}

--- a/syntaxes/LinterSettingsSyntax.json
+++ b/syntaxes/LinterSettingsSyntax.json
@@ -37,6 +37,11 @@
       "description": "Enables the LC0011 rule for Table Fields. (Every object needs to specify a value for the Access property)",
       "type": "boolean",
       "default": false
+    },
+    "enableRule0016ForApiObjects": {
+      "description": "Enables the LC0016 rule for API objects. (Caption is missing)",
+      "type": "boolean",
+      "default": false
     }
   }
 }


### PR DESCRIPTION
Together with https://github.com/StefanMaron/BusinessCentral.LinterCop/pull/265 this is an attempt to solve https://github.com/StefanMaron/BusinessCentral.LinterCop/issues/216.

You would probably want to released this fix a while after the BusinessCentral.LinterCop.dll file is released, I believe.

I had to increase the dependency on vscode, to enable the "deprecated" property in the syntax file. But I believe that most developers are pretty good at keeping VSCode updated, so it should not be a major issue.