### PR TITLE
Always support TLS1.2

### DIFF
--- a/DownloadFile.ps1
+++ b/DownloadFile.ps1
@@ -4,6 +4,9 @@ param (
 )
 $ErrorActionPreference = 'Stop'
 
+# Make sure that the current session supports TLS 1.2
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
 $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/StefanMaron/BusinessCentral.LinterCop/releases"
 
 if ($prerelease -eq "false") {


### PR DESCRIPTION
Hi @StefanMaron,

We have a (now quite old) server where some developers are running VSCode.
It seems as if TLS1.2 is not supported by default in their PowerShell sessions, so the call to download the dll always fails. (without notice as it seems)

I added one line to add support for TLS1.2 before downloading the dll.

This change is only affecting the running PowerShell session, so it should be pretty harmless.