### PR TITLE
Add force to move-item

### DIFF
--- a/DownloadFile.ps1
+++ b/DownloadFile.ps1
@@ -43,7 +43,7 @@ $latestRelease.assets | ForEach-Object  {
         Invoke-WebRequest -Uri $asset.browser_download_url -OutFile (Join-Path $TargetPath $asset.name)
         
         if ($asset.name.EndsWith('current.dll')) {
-            Move-Item (Join-Path $TargetPath $asset.name) (Join-Path $TargetPath 'BusinessCentral.LinterCop.dll')
+            Move-Item (Join-Path $TargetPath $asset.name) (Join-Path $TargetPath 'BusinessCentral.LinterCop.dll') -force
         }
         Set-Content -Value $latestRelease.assets[0].updated_at -Path (Join-Path $PSScriptRoot 'lastversion.txt')
         return 1


### PR DESCRIPTION
If you already have downloaded the lintercop and it tries to move it again an error will appear since it already exists.
I'm having a multiversion pipeline that compiles different versions of the app hence the multiple downloads.