### PR TITLE
Improve handling on $prerelease parameter

### DIFF
--- a/DownloadFile.ps1
+++ b/DownloadFile.ps1
@@ -9,11 +9,17 @@ $ErrorActionPreference = 'Stop'
 
 $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/StefanMaron/BusinessCentral.LinterCop/releases"
 
-if ($prerelease -eq "false") {
+$prerelease = $prerelease.ToString().ToLower()
+
+if ($prerelease -eq "false" -or $prerelease -eq $null) {
     $prerelease = $false
 }
-else {
+elseif ($prerelease -eq "true") {
     $prerelease = $true
+}
+else {
+    Write-Host "Invalid value for parameter prerelease. Please provide True or False."
+    $prerelease = $false
 }
 
 if ($prerelease) {
@@ -57,8 +63,8 @@ return 0
 # SIG # Begin signature block
 # MIISTgYJKoZIhvcNAQcCoIISPzCCEjsCAQExCzAJBgUrDgMCGgUAMGkGCisGAQQB
 # gjcCAQSgWzBZMDQGCisGAQQBgjcCAR4wJgIDAQAABBAfzDtgWUsITrck0sYpfvNR
-# AgEAAgEAAgEAAgEAAgEAMCEwCQYFKw4DAhoFAAQUTo3ZPBcBmkTz4YaX3tIA4KYj
-# jByggg6rMIIG6DCCBNCgAwIBAgIQd70OBbdZC7YdR2FTHj917TANBgkqhkiG9w0B
+# AgEAAgEAAgEAAgEAAgEAMCEwCQYFKw4DAhoFAAQUAlCCE5CD6mknKb5K/hbw76QE
+# Xzuggg6rMIIG6DCCBNCgAwIBAgIQd70OBbdZC7YdR2FTHj917TANBgkqhkiG9w0B
 # AQsFADBTMQswCQYDVQQGEwJCRTEZMBcGA1UEChMQR2xvYmFsU2lnbiBudi1zYTEp
 # MCcGA1UEAxMgR2xvYmFsU2lnbiBDb2RlIFNpZ25pbmcgUm9vdCBSNDUwHhcNMjAw
 # NzI4MDAwMDAwWhcNMzAwNzI4MDAwMDAwWjBcMQswCQYDVQQGEwJCRTEZMBcGA1UE
@@ -141,16 +147,16 @@ return 0
 # QyBSNDUgRVYgQ29kZVNpZ25pbmcgQ0EgMjAyMAIMRmPFdIT8ZL4tC2njMAkGBSsO
 # AwIaBQCgeDAYBgorBgEEAYI3AgEMMQowCKACgAChAoAAMBkGCSqGSIb3DQEJAzEM
 # BgorBgEEAYI3AgEEMBwGCisGAQQBgjcCAQsxDjAMBgorBgEEAYI3AgEVMCMGCSqG
-# SIb3DQEJBDEWBBRXLhonnY4BLx2C3eVLNqepMbjvPDANBgkqhkiG9w0BAQEFAASC
-# AgCEwkTTRChKOnnNCMlhNXUit82HFT7BxB6rUviNuFA/nu4ZN7UKEiK40cqMUt5S
-# gooI04zKAabp4c2anlnlvScuT6i0IE6rOI2gs4E5vImo5eQcMdYy6eqiH88CbzTc
-# Zr6d4ER81PlwZ/gjsJT8+MqYUqZkjVAifhb+7jPMc9vsm6lxpc/6GNE3AcVB0tXg
-# dPgCoLKbfchsv1c4n2fZRqFIxverSpoPDcFg9SnpG92AyY/eH3MuuQpwsPGyVMfz
-# DAk4pGfzym2wFF1JOOWid6fomAhJPP3BazmqtPB41/TNW0JtcFYBuCT4HDpQh/p1
-# IO8BebpbXJCAk2+/ggQQylUbD85L2Z3fOIutGS29C1bjWtWai4Q/VzaXejFxWaNH
-# 0jaa+blibnsA4V/v/UMwNH5JTFC0JgfBYNwhAq14wyFpiFjpvtIMh9eH5bEQBB3c
-# CYrD6RMid+pMFakWWaRcNHQrKXi0spG2TWq/5P9Cb7Sj1qUYahuv1Lwo/O5H9Qo9
-# v0w4KbSmhvx2bABEK7yHzIo9rDGmfkLBnu1pZXAuksukvYtXFjxC3QdTVhI2jTNn
-# NyxBCDzlBsVmu0+ZI46tT9ykJw42yX5gTSJuNxglwYexeGLU6peqfYFfb5JaYjky
-# O+RYhrumlxDl20+Xvwah2G5wB3aM8oiMA7Vo7TovULtQvQ==
+# SIb3DQEJBDEWBBSwiUuqqiiLMQJWsRjCONAbqDkTZDANBgkqhkiG9w0BAQEFAASC
+# AgA6vS7Qxrb71R0dKmJ/8UacFO+zimSR1TTmwLg/cjCY/KGXNlPeuIjRjL3zBIlq
+# rPM43oTKyihYQGfnF01u0+qVmzxCyUcPK5enkyBHp3RWx+kwRxSKUv1hNce90nPZ
+# QlYNOQg8FPv4DvLiXYpwLMiZj9c+frOzhEoNc4/y4g0fBZgDqKh0WmZLb0FErRkW
+# FmJwjsQvH0qLtCH0IIG1baEJr5DdQLhqsm/p/leUnPXW0TRzB3D1XjPK1cJIr9D6
+# iWiPZeWEFcbpy2t9BGBc2ZbeXKDHxcUamKJvo+8/ImlEo4dLpDBvDDR7oTGlqRJB
+# YW9eF7CbHDtOTPTkV883YTh5nIVsnZu0AUJTkDSOlYMnvVAjtnGCBB5bQGOm+zq2
+# bJjEblEld7zVB+2fckf4NJuAcT7AcO3V/Q4eQKi8qxt/aY7zMNW2egabYySmhOAw
+# ktvLkxIfThx8cycbgL56kFMc+YxGxHwgDt39XFUPzCYSTKdO5sly/tkIjvbaks49
+# 785mC1EFdbxiystn4SIL7R/Q7dYP4dZ2YrIm5ZAK+cLN+y824IBtDdD9r98XHZaw
+# S6tKalE8DrFbyEiKUwbOcT9UhaOh1wt6awDdSOCMLNWFZMZRVym8gG+qTiQ7vd+8
+# PNQZYL0NnlMrb/gN5BVFYUbgrdYgbgGVBgD3YEwKEqwJJA==
 # SIG # End signature block

--- a/DownloadFile.ps1
+++ b/DownloadFile.ps1
@@ -9,12 +9,13 @@ $ErrorActionPreference = 'Stop'
 
 $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/StefanMaron/BusinessCentral.LinterCop/releases"
 
-$prerelease = $prerelease.ToString().ToLower()
-
-if ($prerelease -eq "false" -or $prerelease -eq $null) {
+if ($null -eq $prerelease) {
     $prerelease = $false
 }
-elseif ($prerelease -eq "true") {
+elseif ($prerelease.ToString().ToLower() -eq "false") {
+    $prerelease = $false
+}
+elseif ($prerelease.ToString().ToLower() -eq "true") {
     $prerelease = $true
 }
 else {
@@ -36,7 +37,7 @@ if ([string]::IsNullOrEmpty($lastVersionTimeStamp)) {
     $lastVersionTimeStamp = '0001-01-01T00:00:00Z'
 }
 
-$latestRelease.assets | ForEach-Object  {
+$latestRelease.assets | ForEach-Object {
     $asset = $_
     Join-Path $TargetPath $asset.name
     if (((Get-Date $lastVersionTimeStamp) -lt (Get-Date $latestRelease.assets[0].updated_at )) -or (-not (Test-Path (Join-Path $TargetPath $asset.name) -PathType leaf))) {
@@ -63,8 +64,8 @@ return 0
 # SIG # Begin signature block
 # MIISTgYJKoZIhvcNAQcCoIISPzCCEjsCAQExCzAJBgUrDgMCGgUAMGkGCisGAQQB
 # gjcCAQSgWzBZMDQGCisGAQQBgjcCAR4wJgIDAQAABBAfzDtgWUsITrck0sYpfvNR
-# AgEAAgEAAgEAAgEAAgEAMCEwCQYFKw4DAhoFAAQUAlCCE5CD6mknKb5K/hbw76QE
-# Xzuggg6rMIIG6DCCBNCgAwIBAgIQd70OBbdZC7YdR2FTHj917TANBgkqhkiG9w0B
+# AgEAAgEAAgEAAgEAAgEAMCEwCQYFKw4DAhoFAAQUxwFjeQPE0i8UQrfz2wCDmPT8
+# VAyggg6rMIIG6DCCBNCgAwIBAgIQd70OBbdZC7YdR2FTHj917TANBgkqhkiG9w0B
 # AQsFADBTMQswCQYDVQQGEwJCRTEZMBcGA1UEChMQR2xvYmFsU2lnbiBudi1zYTEp
 # MCcGA1UEAxMgR2xvYmFsU2lnbiBDb2RlIFNpZ25pbmcgUm9vdCBSNDUwHhcNMjAw
 # NzI4MDAwMDAwWhcNMzAwNzI4MDAwMDAwWjBcMQswCQYDVQQGEwJCRTEZMBcGA1UE
@@ -147,16 +148,16 @@ return 0
 # QyBSNDUgRVYgQ29kZVNpZ25pbmcgQ0EgMjAyMAIMRmPFdIT8ZL4tC2njMAkGBSsO
 # AwIaBQCgeDAYBgorBgEEAYI3AgEMMQowCKACgAChAoAAMBkGCSqGSIb3DQEJAzEM
 # BgorBgEEAYI3AgEEMBwGCisGAQQBgjcCAQsxDjAMBgorBgEEAYI3AgEVMCMGCSqG
-# SIb3DQEJBDEWBBSwiUuqqiiLMQJWsRjCONAbqDkTZDANBgkqhkiG9w0BAQEFAASC
-# AgA6vS7Qxrb71R0dKmJ/8UacFO+zimSR1TTmwLg/cjCY/KGXNlPeuIjRjL3zBIlq
-# rPM43oTKyihYQGfnF01u0+qVmzxCyUcPK5enkyBHp3RWx+kwRxSKUv1hNce90nPZ
-# QlYNOQg8FPv4DvLiXYpwLMiZj9c+frOzhEoNc4/y4g0fBZgDqKh0WmZLb0FErRkW
-# FmJwjsQvH0qLtCH0IIG1baEJr5DdQLhqsm/p/leUnPXW0TRzB3D1XjPK1cJIr9D6
-# iWiPZeWEFcbpy2t9BGBc2ZbeXKDHxcUamKJvo+8/ImlEo4dLpDBvDDR7oTGlqRJB
-# YW9eF7CbHDtOTPTkV883YTh5nIVsnZu0AUJTkDSOlYMnvVAjtnGCBB5bQGOm+zq2
-# bJjEblEld7zVB+2fckf4NJuAcT7AcO3V/Q4eQKi8qxt/aY7zMNW2egabYySmhOAw
-# ktvLkxIfThx8cycbgL56kFMc+YxGxHwgDt39XFUPzCYSTKdO5sly/tkIjvbaks49
-# 785mC1EFdbxiystn4SIL7R/Q7dYP4dZ2YrIm5ZAK+cLN+y824IBtDdD9r98XHZaw
-# S6tKalE8DrFbyEiKUwbOcT9UhaOh1wt6awDdSOCMLNWFZMZRVym8gG+qTiQ7vd+8
-# PNQZYL0NnlMrb/gN5BVFYUbgrdYgbgGVBgD3YEwKEqwJJA==
+# SIb3DQEJBDEWBBRYG6PzREwiB/Gb1TYHPa7JTf92NDANBgkqhkiG9w0BAQEFAASC
+# AgCLtlVEKY7Y5C1Af0upwhsrGqIuPcGsiuvk734gmJhedjRddJw/5vu0Id9LhUxq
+# X9sV899qi8md3WunifP2OUc/5j2JnMr09scdpiuK+0O2M0AnJf4RUnPltTloUKlc
+# SZhIEQu4qHoEJGmbHf9e7qHm9ImdJkYBreDyysZGtiz2c5qkLRrtIVkqntM9sxfn
+# 6Fz1Hgc+8W25kvEjhxlA8vT3cGkIEWG3YNKWUm2dTBkVOR44QWnanuc3lqsuynDK
+# GAnTamp4NXrLs5lT7OdWljdPuYr7tmbLFAgo5ff9fyqZLeFb9xIQN6eKXue1SRMO
+# F4vlZlASVwpYxhzbJ/zLBU0G0Vxja3k99wbozS+5tpAj6YXxM5m5DGZX260hs/IB
+# jrGyhCpEQjCyw4ch5KvhvZX2HoK1bHr7Hfki4xotN1BuvH+eIt2Xxn5AujowAxUU
+# Vnw7/PjuEREn9SBwbg2YIHwM5+FDBOEamGEZRKu+D0ge970nalsPY7ShpKqbJjVQ
+# fNdf3KvAocm090MiTvbN95Zg//BWGWxF+R23X3xFUWlottJCf/g6yfmPKt20DfWU
+# TJji7/PGmLL1AbwFQpk9+OiuzjH+FrtZT0qeHh/lg7ucIG+ZSiDvHdWSWNzMcKz0
+# peCsEVY1n2wbWnlzRBP695jsV83nRcIEl8ZPbJ3ZvBenVw==
 # SIG # End signature block

--- a/DownloadFile.ps1
+++ b/DownloadFile.ps1
@@ -12,15 +12,19 @@ $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/StefanMaro
 if ($null -eq $prerelease) {
     $prerelease = $false
 }
-elseif ($prerelease.ToString().ToLower() -eq "false") {
-    $prerelease = $false
-}
-elseif ($prerelease.ToString().ToLower() -eq "true") {
-    $prerelease = $true
-}
 else {
-    Write-Host "Invalid value for parameter prerelease. Please provide True or False."
-    $prerelease = $false
+    Switch ($prerelease.ToString().ToLower()) {
+        "false" { 
+            $prerelease = $false
+        }
+        "true" {
+            $prerelease = $true
+        }
+        default {
+            Write-Host "Invalid value for parameter prerelease. Please provide True or False."
+            $prerelease = $false
+        }
+    }
 }
 
 if ($prerelease) {
@@ -64,8 +68,8 @@ return 0
 # SIG # Begin signature block
 # MIISTgYJKoZIhvcNAQcCoIISPzCCEjsCAQExCzAJBgUrDgMCGgUAMGkGCisGAQQB
 # gjcCAQSgWzBZMDQGCisGAQQBgjcCAR4wJgIDAQAABBAfzDtgWUsITrck0sYpfvNR
-# AgEAAgEAAgEAAgEAAgEAMCEwCQYFKw4DAhoFAAQUxwFjeQPE0i8UQrfz2wCDmPT8
-# VAyggg6rMIIG6DCCBNCgAwIBAgIQd70OBbdZC7YdR2FTHj917TANBgkqhkiG9w0B
+# AgEAAgEAAgEAAgEAAgEAMCEwCQYFKw4DAhoFAAQUcwrF6/cf6Us3N5uFfnr6/BGH
+# Xxiggg6rMIIG6DCCBNCgAwIBAgIQd70OBbdZC7YdR2FTHj917TANBgkqhkiG9w0B
 # AQsFADBTMQswCQYDVQQGEwJCRTEZMBcGA1UEChMQR2xvYmFsU2lnbiBudi1zYTEp
 # MCcGA1UEAxMgR2xvYmFsU2lnbiBDb2RlIFNpZ25pbmcgUm9vdCBSNDUwHhcNMjAw
 # NzI4MDAwMDAwWhcNMzAwNzI4MDAwMDAwWjBcMQswCQYDVQQGEwJCRTEZMBcGA1UE
@@ -148,16 +152,16 @@ return 0
 # QyBSNDUgRVYgQ29kZVNpZ25pbmcgQ0EgMjAyMAIMRmPFdIT8ZL4tC2njMAkGBSsO
 # AwIaBQCgeDAYBgorBgEEAYI3AgEMMQowCKACgAChAoAAMBkGCSqGSIb3DQEJAzEM
 # BgorBgEEAYI3AgEEMBwGCisGAQQBgjcCAQsxDjAMBgorBgEEAYI3AgEVMCMGCSqG
-# SIb3DQEJBDEWBBRYG6PzREwiB/Gb1TYHPa7JTf92NDANBgkqhkiG9w0BAQEFAASC
-# AgCLtlVEKY7Y5C1Af0upwhsrGqIuPcGsiuvk734gmJhedjRddJw/5vu0Id9LhUxq
-# X9sV899qi8md3WunifP2OUc/5j2JnMr09scdpiuK+0O2M0AnJf4RUnPltTloUKlc
-# SZhIEQu4qHoEJGmbHf9e7qHm9ImdJkYBreDyysZGtiz2c5qkLRrtIVkqntM9sxfn
-# 6Fz1Hgc+8W25kvEjhxlA8vT3cGkIEWG3YNKWUm2dTBkVOR44QWnanuc3lqsuynDK
-# GAnTamp4NXrLs5lT7OdWljdPuYr7tmbLFAgo5ff9fyqZLeFb9xIQN6eKXue1SRMO
-# F4vlZlASVwpYxhzbJ/zLBU0G0Vxja3k99wbozS+5tpAj6YXxM5m5DGZX260hs/IB
-# jrGyhCpEQjCyw4ch5KvhvZX2HoK1bHr7Hfki4xotN1BuvH+eIt2Xxn5AujowAxUU
-# Vnw7/PjuEREn9SBwbg2YIHwM5+FDBOEamGEZRKu+D0ge970nalsPY7ShpKqbJjVQ
-# fNdf3KvAocm090MiTvbN95Zg//BWGWxF+R23X3xFUWlottJCf/g6yfmPKt20DfWU
-# TJji7/PGmLL1AbwFQpk9+OiuzjH+FrtZT0qeHh/lg7ucIG+ZSiDvHdWSWNzMcKz0
-# peCsEVY1n2wbWnlzRBP695jsV83nRcIEl8ZPbJ3ZvBenVw==
+# SIb3DQEJBDEWBBTMH1pbJNucBiNTAZn09OdKAbKi4TANBgkqhkiG9w0BAQEFAASC
+# AgB/WE8xP4tKuQIibDD6GW5X+eTSIoqmI+vwHq/IpAcJGkVH8qWFh4IJ1PRsZGtf
+# iGu5X5GiT0oy1C3rX+ynoW0Dc6LOyPBy7C73cEKAC3sEJTP/za+N2MiHetoggjRp
+# FujIaBRCnahq2uFBQBsBuuDDGgeYZslpROmYqGpjJD9sVe6Enz7lzWp7KhJEnmGQ
+# df1s32N/wX/Vqc40DQuWIxWVsD4opJy7ha8vAqO+jNWqiSmd6LWINA8N5JxLxm21
+# JzgQjGE5UXvhhRv39E9bcLKqJkaNdtekdeYEShI1OVkLAcOsYjAXqiT0OaKIGfZ8
+# rSYRvc6ccRbr+LVIt3HSaY4IuecSmWX++oX8PG6ZBAE3JOnYvPFxi1+6LVHC5aK3
+# At40EE9cM3Ug8H4qG46dLgv8hCGoW/fqLn1fRlw8jf7bQnLIJSacZNJZtKVrUn9f
+# GNOQMs+S+U42PZu5AM2mRGzvQsV40Z5teJS0uqH2jt9BFgcbt+PNEiAvuJmYAfHN
+# 44wniHxBc7g5jYsp4sF9qjsQkkgjycZ6OanfJskYGa1UnJqd5vvbczdhBInwDeID
+# GUF869VT9j8pDC8uGkkGL02j5NazAp67rQJqx0PQYhS5AWP/PJXXmjf5tCgdVQOA
+# 3oXoZEFeLs0wWS3oMxiW6/EjaAIbKQblime6xXcCABEbTw==
 # SIG # End signature block


### PR DESCRIPTION
![image](https://github.com/StefanMaron/BusinessCentral.LinterCop/assets/34970096/50f77f69-be05-4990-b4d9-9b4a6c3fe7e2)
This format of the input parameter doesn't support `$false`, where it will result in the value `true`.

With this PR I've improved the validation of the `-prerelease` flag.

```PS
DownloadFile.ps1 -TargetPath ""
DownloadFile.ps1 -TargetPath "" -prerelease false
DownloadFile.ps1 -TargetPath "" -prerelease False
DownloadFile.ps1 -TargetPath "" -prerelease $False
DownloadFile.ps1 -TargetPath "" -prerelease SomeRandomValue
```
These examples will download the `Latest` version.

```PS
DownloadFile.ps1 -TargetPath "" -prerelease true
DownloadFile.ps1 -TargetPath "" -prerelease True
DownloadFile.ps1 -TargetPath "" -prerelease $True
```
These examples will download the `Pre-release` version.

More details on https://github.com/StefanMaron/BusinessCentral.LinterCop/issues/500.