### PR TITLE
Less intrusive extension 

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
         "Linters"
     ],
     "activationEvents": [
-        "*"
+        "onLanguage:al",
+        "workspaceContains:app.json",
+        "onCommand:al.go"
     ],
     "main": "./out/extension.js",
     "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,6 @@ export function activate(context: ExtensionContext) {
 
     // Initialize the output channel
     outputChannel = window.createOutputChannel('LinterCop');
-    outputChannel.show(true);
     outputChannel.appendLine('LinterCop output channel created.');
 
     console.log('BusinessCentral LinterCop extension is now active!');


### PR DESCRIPTION
A couple of things has annoyed me a bit with this extension. No biggies, but when you're annoyed enough - you'd better do something about it! 😅

1. This extension is getting loaded for all VSCode projects, even if it is not a AL project. This results in a error message like this:
![image](https://github.com/user-attachments/assets/10613b25-3fcf-415f-ab1e-828dba3c17c6)
![image](https://github.com/user-attachments/assets/04932bfc-4584-421a-9047-eb1e573d755d)
2. The Output channel for LinterCop is stealing focus on every restart of VSCode

I made two small changes to adress this
1. Only activate this extension on either of these three conditions:
  - AL language is active
  - There is an app.json in the workspace
  - The command al.go is available (the AL Extension is loaded)
2. Never show the output channel from code. The user has to select the output manually to see that information. I can't see that as a problem, since the user gets prompted both on update of LC and on failures to update. And if no update is needed, I don't think the developer needs that information on every reload of VSCode.

What do you think about above changes?
