### PR TITLE
Properly handle download from private repositories

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -244,7 +244,11 @@ async function getDownloadUrl(apiUrl: string, loadPreRelease: boolean, alLanguag
                 }
 
                 if (asset) {
-                    resolve(asset.browser_download_url);
+                    if (token) {
+                        resolve(asset.url);
+                    } else {
+                        resolve(asset.browser_download_url);
+                    }
                 } else {
                     reject(new Error('No suitable asset found in the latest release.'));
                 }
@@ -264,6 +268,7 @@ function downloadFile(url: string, dest: string, token: string): Promise<void> {
         };
         if (token) {
             (options.headers as any)['Authorization'] = `token ${token}`;
+            (options.headers as any)['Accept'] = 'application/octet-stream';
         }
         const request = https.get(url, options, response => {
             if (response.statusCode === 302 && response.headers.location) {


### PR DESCRIPTION
The `browser_download_url` does not work for release assets from private repositories (see also [this discussion in the GitHub community organisation](https://github.com/orgs/community/discussions/47453)). Instead, the direct link to the asset should be called with an `Accept` header of `application/octet-stream`, which results in a properly authenticated file download.

It's fairly safe to assume that we're dealing with a private repository if the `token` is set (and thus needing to use this alternative download flow), but feel free to suggest other ways of doing this if you have any ideas.